### PR TITLE
The Turing Way: Adding missing text in the proposal

### DIFF
--- a/projects/9/README.md
+++ b/projects/9/README.md
@@ -2,7 +2,27 @@
 
 ## Abstract
 
-Reproducible and ethical research is necessary to ensure that scientific work can be trusted. Funders and different stakeholders of scientific projects are beginning to require that publications and research outreach include access to the underlying data and analysis code. The goal is to ensure that all results can be independently verified and built upon in future work. This is sometimes easier said than done. Sharing data and code in bioinformatics require a common understanding of the scientific concepts, data management, software development, and data sharing techniques: skills that are ...
+Reproducible and ethical research is necessary to ensure that scientific work can be trusted. Funders and different stakeholders of scientific projects are beginning to require that publications and research outreach include access to the underlying data and analysis code. The goal is to ensure that all results can be independently verified and built upon in future work. This is sometimes easier said than done. Sharing data and code in bioinformatics require a common understanding of the scientific concepts, data management, software development, and data sharing techniques: skills that are not widely taught or expected of academic researchers and bioinformaticians. 
+
+The Turing Way is an open-source, community-led, and collaboratively developed project on making data research accessible for a wider research community (https://the-turing-way.netlify.com). We bring together individuals from diverse fields and expertise to develop practices and learning resources that can make data research comprehensible and useful for everyone. These resources are organised as book chapters online and all questions, comments, recommendations, and discussions are facilitated through an online GitHub repository (https://github.com/alan-turing-institute/the-turing-way).
+
+Aligned with the goals of ELIXIR, The Turing Way promotes best practices, tools, and recommendations used by the scientific communities worldwide. Our community members are researchers, engineers, data librarians, industry professionals, and experts in various domains, at all levels of seniority, including from the ELIXIR network. Since the project's launch in April 2019, they have co-authored chapters that include training and learning resources on version control, data analysis, code review, testing, open collaboration, and scholarly communication. 
+
+We recognize that the book in its current state is missing important practices and examples from life science and data research currently being conducted in bioinformatics. We aim to fill that gap by capturing the ongoing effort in the ELIXIR bioinformatics network.
+
+At the Biohackathon, we will engage with attendees and ELIXIR members in documenting their experience related to bioinformatics in the form of technical skills, case studies, examples and other learning resources. We will support participants in creating a list of essential skills in life science that they would like to share with the wider research community. 
+
+During the hackathon, we will focus on creating resources that are usable by the hackathon attendees and make them immediately available online under CC-BY license. After the hackathon, contributors can continue to contribute and improve their contributions or other chapters in the book.
+
+Skills and contributions that we're looking for include, but are not limited to:
+
+- examples and case studies of reproducible research in life science 
+- reviewing and editing of the current chapters on reproducibility, i.e. GitHub, git, Jupyter, Binder, continuous integration, license, FAIR principles, etc.
+- designing resources on science communication skills: skills in writing, editing, visualizing and sharing the scientific outcome
+- developing new chapters on topics such as project design, collaboration and data research skilled inspired by their projects
+- updating the interactivity of The Turing Way book (https://the-turing-way.netlify.com)
+- technical understanding of Jupyter book, Markdown, git, GitHub, Binder and online books will be useful - though not required.
+
 
 ## Topics
 
@@ -25,8 +45,7 @@ AUTHOR1 Malvika Sharan (msharan@turing.ac.uk)
 
 ### Nominated participant(s)
 
-Tony Yang (tony@tony.ac)
- Sarah Gibson (sgibson@turing.ac.uk)
+None at the moment.
 
 ## Expected outcomes
 


### PR DESCRIPTION
## Summary

The abstract is partially added that can misguide readers

Would appreciate if the full text can be added. If not necessary, please add a link to our project repo: https://github.com/alan-turing-institute/the-turing-way